### PR TITLE
Graying out multiplayer and join room card

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,7 @@
         "react-router-dom": "^6.23.1",
         "react-scripts": "^5.0.1",
         "react-timer-hook": "^3.0.7",
+        "react-tooltip": "^5.28.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -15291,6 +15292,20 @@
       "integrity": "sha512-ATpNcU+PQRxxfNBPVqce2+REtjGAlwmfoNQfcEBMZFxPj0r3GYdKhyPHdStvqrejejEi0QvqaJZjy2lBlFvAsA==",
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.28.0.tgz",
+      "integrity": "sha512-R5cO3JPPXk6FRbBHMO0rI9nkUG/JKfalBSQfZedZYzmqaZQgq7GLzF8vcCWx6IhUCKg0yPqJhXIzmIO5ff15xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/read-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "react-router-dom": "^6.23.1",
     "react-scripts": "^5.0.1",
     "react-timer-hook": "^3.0.7",
+    "react-tooltip": "^5.28.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/client/src/components/cards/ComingSoonCard.jsx
+++ b/client/src/components/cards/ComingSoonCard.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Tooltip } from 'react-tooltip'
+
+/**
+ * Component responsible for creation of the grayed out cards, i.e. Multiplayer and join multiplayer room which will come in v2 of como se dice.
+ * @param { String  } title Title of the card 
+ * @param { String  } body Body of the card 
+* @returns Coming soon card.
+ */
+function ComingSoonCard({title, body}) {
+  return (
+    <div className="h-[23vh] border-solid border border-sky-500 rounded-lg shadow-2xl grayscale-0">
+        {/* This is the <a> tag that will have the tags for the tooltip, id, content (message), and how long the message will show. */}
+        <a data-tooltip-id="my-tooltip" data-tooltip-content="Coming in ¿cómo se dice? 2.0" data-tooltip-delay-hide={300}>
+            <div className="flex items-center justify-center h-full w-full">
+                <div className="flex items-center justify-center h-full w-full text-center">
+                    <h2 className='text-xl text-gray-400'>
+                            {title}
+                            <span> &rarr;</span>
+                        
+                            <p>
+                                {body}
+                            </p>
+                        </h2>
+                </div>
+            </div>
+        </a>
+
+        {/* This is what makes the tooltip work. This will bet the id of the <a> tag and will show the message that is specified in the a tag */}
+        <Tooltip id="my-tooltip"></Tooltip>
+        
+    </div>
+  )
+}
+
+export default ComingSoonCard

--- a/client/src/pages/ComoSeDiceMenu.js
+++ b/client/src/pages/ComoSeDiceMenu.js
@@ -1,6 +1,7 @@
 import "../css/App.css";
 import SinglePlayer from "../components/cards/SinglePlayerCard.jsx";
 import DailyChallenge from "../components/cards/DailyChallengeCard.jsx";
+import ComingSoonCard from "../components/cards/ComingSoonCard.jsx";
 
 /**
  * Como se dice menu page.
@@ -21,11 +22,10 @@ function ComoSeDiceMenu() {
               body="Play cómo se dice alone"
             />
 
-            <DailyChallenge
-              destination="/comosedice/comingsoon"
+            <ComingSoonCard
               title="Multiplayer"
               body="Start a room to play against friends!"
-            />
+            ></ComingSoonCard>
 
             <DailyChallenge
               destination="/comosedice/dailychallenge"
@@ -33,11 +33,10 @@ function ComoSeDiceMenu() {
               body="Get as many words right in the shortest time and see where you stack up against the world 🌐! "
             />
 
-            <DailyChallenge
-              destination="/comosedice/comingsoon"
+            <ComingSoonCard
               title="Join Multiplayer Room"
               body="Room code"
-            />
+            ></ComingSoonCard>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Major changes
Graying out the `Multiplayer `and `Join Multiplayer Room` and using [react-tooltip library](https://react-tooltip.com/docs/getting-started) to show a message saying these features are coming in version 2 of como se dice.